### PR TITLE
use bottom modal instead of offstage

### DIFF
--- a/unit_converter/server.js
+++ b/unit_converter/server.js
@@ -70,7 +70,7 @@ const server = http.createServer((req, res) => {
             res.statusCode = '400';
             res.end(JSON.stringify({'status': 'error', 'message': message}));
         }
-        res.end(JSON.stringify({'status': 'ok', 'conversion': units.amount * from/to}));
+        res.end(JSON.stringify({'status': 'ok', 'conversion': units.amount * to/from}));
     } else {
         res.end('Welcome to the API for the Unit Converter!');
     }

--- a/unit_converter/unit_converter/lib/api.dart
+++ b/unit_converter/unit_converter/lib/api.dart
@@ -56,23 +56,20 @@ class Api {
       String category, String amount, String fromUnit, String toUnit) async {
     // You can directly call httpClient.get() with a String as input,
     // but to make things cleaner, we can pass in a Uri.
-    var uri = new Uri.https(url, '/$category/convert', {
-      'amount': amount,
-      'from': fromUnit,
-      'to': toUnit
-    });
+    var uri = new Uri.https(url, '/$category/convert',
+        {'amount': amount, 'from': fromUnit, 'to': toUnit});
     try {
       var response = await httpClient.get(uri);
-    if (response.statusCode != 200) {
-      return null;
-    }
-    var jsonResponse = JSON.decode(response.body);
-    try {
-      return jsonResponse['conversion'].toDouble();
-    } on Exception catch (e) {
-      print('Error: $e $jsonResponse["message"]');
-      return null;
-    }
+      if (response.statusCode != 200) {
+        return null;
+      }
+      var jsonResponse = JSON.decode(response.body);
+      try {
+        return jsonResponse['conversion'].toDouble();
+      } on Exception catch (e) {
+        print('Error: $e $jsonResponse["message"]');
+        return null;
+      }
     } on Exception catch (e) {
       print('Error: $e');
       return null;

--- a/unit_converter/unit_converter/lib/category.dart
+++ b/unit_converter/unit_converter/lib/category.dart
@@ -57,40 +57,45 @@ class Category extends StatelessWidget {
   /// Builds a tile that shows unit [Category] information
   @override
   Widget build(BuildContext context) {
-    return new Container(
-      child: new Material(
-        child: new FlatButton(
-          color: color[100],
-          onPressed: () => _navigateToConverter(context),
-          child: new Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
-              new Expanded(
+    return new Stack(
+      children: <Widget>[
+        new Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            new Expanded(
+              child: new Container(
+                color: color[100],
                 child: new Icon(
                   icon,
                   size: 40.0,
                 ),
               ),
-              new Container(
-                height: 30.0,
-                width: 500.0,
-                color: Colors.grey[200],
-                child: new Center(
-                  child: new Text(
-                    name,
-                    textAlign: TextAlign.center,
-                    style: new TextStyle(
-                      color: Colors.black,
-                      fontSize: 18.0,
-                      fontWeight: FontWeight.w700,
-                    ),
+            ),
+            new Container(
+              height: 30.0,
+              color: Colors.grey[200],
+              child: new Center(
+                child: new Text(
+                  name,
+                  textAlign: TextAlign.center,
+                  style: new TextStyle(
+                    color: Colors.black,
+                    fontSize: 18.0,
+                    fontWeight: FontWeight.w700,
                   ),
                 ),
               ),
-            ],
-          ),
+            ),
+          ],
         ),
-      ),
+        // Adds inkwell animation when tapped
+        new Material(
+          child: new InkWell(
+            onTap: () => _navigateToConverter(context),
+          ),
+          color: Colors.transparent,
+        ),
+      ],
     );
   }
 }

--- a/unit_converter/unit_converter/lib/category.dart
+++ b/unit_converter/unit_converter/lib/category.dart
@@ -73,6 +73,7 @@ class Category extends StatelessWidget {
               ),
               new Container(
                 height: 30.0,
+                width: 500.0,
                 color: Colors.grey[200],
                 child: new Center(
                   child: new Text(

--- a/unit_converter/unit_converter/lib/category_route.dart
+++ b/unit_converter/unit_converter/lib/category_route.dart
@@ -243,7 +243,12 @@ class _CategoryRouteState extends State<CategoryRoute> {
     var grid = new Container(
       color: Colors.white,
       padding: widget.footer
-          ? const EdgeInsets.only(bottom: 16.0, left: 16.0, right: 16.0)
+          ? const EdgeInsets.only(
+              bottom: 16.0,
+              left: 16.0,
+              right: 16.0,
+              top: 4.0,
+            )
           : const EdgeInsets.all(16.0),
       child: new Column(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
@@ -254,7 +259,9 @@ class _CategoryRouteState extends State<CategoryRoute> {
 
     if (widget.footer) {
       return new Container(
-          height: deviceSize.height - 200.0, color: Colors.red, child: grid);
+        height: 500.0,
+        child: grid,
+      );
     }
 
     var headerBar = new AppBar(

--- a/unit_converter/unit_converter/lib/converter_route.dart
+++ b/unit_converter/unit_converter/lib/converter_route.dart
@@ -45,7 +45,6 @@ class _ConverterRouteState extends State<ConverterRoute> {
   Unit _toValue;
   String _inputValue;
   String _convertedValue = 'Output';
-  bool _showCategories = false;
   bool _showErrorUI = false;
 
   Future<Null> _updateConversion() async {
@@ -123,12 +122,6 @@ class _ConverterRouteState extends State<ConverterRoute> {
       _toValue = _getUnit(unitName);
     });
     _updateConversion();
-  }
-
-  void _toggleCategories() {
-    setState(() {
-      _showCategories = !_showCategories;
-    });
   }
 
   @override
@@ -312,7 +305,7 @@ class _ConverterRouteState extends State<ConverterRoute> {
               _toValue.description,
               style: Theme.of(context).textTheme.title,
             ),
-            margin: _bottomMargin,
+            margin: _bottomMargin * 1.5,
           ),
         ],
       ),
@@ -333,38 +326,53 @@ class _ConverterRouteState extends State<ConverterRoute> {
       ),
     );
 
+    var selectCategoryHeader = new Container(
+      alignment: FractionalOffset.bottomLeft,
+      padding: const EdgeInsets.symmetric(
+        vertical: 16.0,
+        horizontal: 32.0,
+      ),
+      child: new Text(
+        'Select category',
+        style: Theme.of(context).textTheme.subhead.copyWith(
+              fontWeight: FontWeight.w600,
+              color: Colors.grey[700],
+            ),
+      ),
+      decoration: new BoxDecoration(
+        borderRadius: new BorderRadius.only(
+          topLeft: new Radius.circular(32.0),
+          topRight: new Radius.circular(32.0),
+        ),
+        color: Colors.white,
+      ),
+    );
+
     var selectCategoryScreen = new Column(
       mainAxisAlignment: MainAxisAlignment.end,
       children: <Widget>[
         new GestureDetector(
-          onTap: _toggleCategories,
-          child: new Container(
-            alignment: FractionalOffset.bottomLeft,
-            padding: const EdgeInsets.symmetric(
-              vertical: 16.0,
-              horizontal: 32.0,
-            ),
-            child: new Text(
-              'Select category',
-              style: Theme.of(context).textTheme.subhead.copyWith(
-                    fontWeight: FontWeight.w600,
-                    color: Colors.grey[700],
-                  ),
-            ),
-            decoration: new BoxDecoration(
-              borderRadius: new BorderRadius.only(
-                topLeft: new Radius.circular(32.0),
-                topRight: new Radius.circular(32.0),
-              ),
-              color: Colors.white,
-            ),
-          ),
+          onTap: () {
+            showModalBottomSheet<Null>(
+                context: context,
+                builder: (BuildContext context) {
+                  return new Container(
+                    child: new SingleChildScrollView(
+                      child: new Column(
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        children: <Widget>[
+                          selectCategoryHeader,
+                          new CategoryRoute(
+                            footer: true,
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                });
+          },
+          child: selectCategoryHeader,
         ),
-        _showCategories
-            ? new CategoryRoute(
-                footer: true,
-              )
-            : new Container(),
       ],
     );
 


### PR DESCRIPTION
 - For the Select Category Slider at the bottom, use a bottom modal instead of an Offstage. This adds the animation for the bottom modal opening.
 - Updates the Category grid square to have a full grey bar on the bottom instead of a partial grey bar
 - Also fixes a math bug in the server.js file.

<img width="327" alt="screen shot 2018-01-03 at 1 49 34 pm" src="https://user-images.githubusercontent.com/3357543/34541441-0ad5ae96-f08d-11e7-82a4-cabdb5abfb65.png"> <img width="355" alt="screen shot 2018-01-03 at 1 49 46 pm" src="https://user-images.githubusercontent.com/3357543/34541442-0ae0af58-f08d-11e7-8e50-8a984be8b189.png">

<img width="315" alt="screen shot 2018-01-03 at 3 08 39 pm" src="https://user-images.githubusercontent.com/3357543/34543887-0ffe46b6-f098-11e7-8ee6-5d8f0f46dbf1.png">
