### PR TITLE
Remove references to createHttpClient

### DIFF
--- a/unit_converter/unit_converter/lib/api.dart
+++ b/unit_converter/unit_converter/lib/api.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert' show JSON, UTF8;
+import 'dart:convert' show json, utf8;
 import 'dart:io';
 
 /// The REST API retrieves unit conversions for [Categories] that change.
@@ -16,7 +16,7 @@ import 'dart:io';
 ///   GET /currency/convert: get conversion from one currency amount to another
 class Api {
   // We use the `dart:io` HttpClient. More details: https://flutter.io/networking/
-  final httpClient = new HttpClient();
+  final httpClient = HttpClient();
 
   /// The API endpoint we want to hit.
   ///
@@ -28,8 +28,6 @@ class Api {
   /// [category] is the category from which to retrieve units.
   /// Returns a list. Prints exception silently.
   Future<List> getUnits(String category) async {
-    // You can directly call httpClient.get() with a String as input,
-    // but to make things cleaner, we can pass in a Uri.
     final uri = Uri.https(url, '/$category');
     try {
       final request = await httpClient.getUrl(uri);
@@ -37,8 +35,8 @@ class Api {
       if (response.statusCode != 200) {
         return null;
       }
-      final responseBody = await response.transform(UTF8.decoder).join();
-      final jsonResponse = JSON.decode(responseBody);
+      final responseBody = await response.transform(utf8.decoder).join();
+      final jsonResponse = json.decode(responseBody);
       try {
         return jsonResponse['units'];
       } on Exception catch (e) {
@@ -56,8 +54,6 @@ class Api {
   /// Returns a double, which is the converted amount.
   Future<double> convert(
       String category, String amount, String fromUnit, String toUnit) async {
-    // You can directly call httpClient.get() with a String as input,
-    // but to make things cleaner, we can pass in a Uri.
     final uri = Uri.https(url, '/$category/convert',
         {'amount': amount, 'from': fromUnit, 'to': toUnit});
     try {
@@ -66,8 +62,8 @@ class Api {
       if (response.statusCode != 200) {
         return null;
       }
-      final responseBody = await response.transform(UTF8.decoder).join();
-      final jsonResponse = JSON.decode(responseBody);
+      final responseBody = await response.transform(utf8.decoder).join();
+      final jsonResponse = json.decode(responseBody);
       try {
         return jsonResponse['conversion'].toDouble();
       } on Exception catch (e) {

--- a/unit_converter/unit_converter/lib/api.dart
+++ b/unit_converter/unit_converter/lib/api.dart
@@ -30,13 +30,7 @@ class Api {
   Future<List> getUnits(String category) async {
     final uri = Uri.https(url, '/$category');
     try {
-      final request = await httpClient.getUrl(uri);
-      final response = await request.close();
-      if (response.statusCode != 200) {
-        return null;
-      }
-      final responseBody = await response.transform(utf8.decoder).join();
-      final jsonResponse = json.decode(responseBody);
+      final jsonResponse = await getJson(uri);
       try {
         return jsonResponse['units'];
       } on Exception catch (e) {
@@ -57,13 +51,7 @@ class Api {
     final uri = Uri.https(url, '/$category/convert',
         {'amount': amount, 'from': fromUnit, 'to': toUnit});
     try {
-      final request = await httpClient.getUrl(uri);
-      final response = await request.close();
-      if (response.statusCode != 200) {
-        return null;
-      }
-      final responseBody = await response.transform(utf8.decoder).join();
-      final jsonResponse = json.decode(responseBody);
+      final jsonResponse = await getJson(uri);
       try {
         return jsonResponse['conversion'].toDouble();
       } on Exception catch (e) {
@@ -74,5 +62,19 @@ class Api {
       print('Error: $e');
       return null;
     }
+  }
+
+  /// Fetches and decodes a Json object represented as a dart `Map`.
+  Future<Map<String, dynamic>> getJson(Uri uri) async {
+    final httpRequest = await httpClient.getUrl(uri);
+    final httpResponse = await httpRequest.close();
+    if (httpResponse.statusCode != HttpStatus.OK) {
+      return null;
+    }
+    // The response is sent as a Stream of bytes that we need to convert to a
+    // `String`.
+    final responseBody = await httpResponse.transform(utf8.decoder).join();
+    // Finally, the string is parsed into a Json object.
+    return json.decode(responseBody);
   }
 }

--- a/unit_converter/unit_converter/lib/api.dart
+++ b/unit_converter/unit_converter/lib/api.dart
@@ -3,9 +3,8 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert' show JSON;
-
-import 'package:flutter/services.dart';
+import 'dart:convert' show JSON, UTF8;
+import 'dart:io';
 
 /// The REST API retrieves unit conversions for [Categories] that change.
 ///
@@ -16,8 +15,8 @@ import 'package:flutter/services.dart';
 ///   GET /currency: get a list of currencies
 ///   GET /currency/convert: get conversion from one currency amount to another
 class Api {
-  // We use the `http` package. More details: https://flutter.io/networking/
-  final httpClient = createHttpClient();
+  // We use the `dart:io` HttpClient. More details: https://flutter.io/networking/
+  final httpClient = new HttpClient();
 
   /// The API endpoint we want to hit.
   ///
@@ -33,11 +32,13 @@ class Api {
     // but to make things cleaner, we can pass in a Uri.
     final uri = Uri.https(url, '/$category');
     try {
-      final response = await httpClient.get(uri);
+      final request = await httpClient.getUrl(uri);
+      final response = await request.close();
       if (response.statusCode != 200) {
         return null;
       }
-      final jsonResponse = JSON.decode(response.body);
+      final responseBody = await response.transform(UTF8.decoder).join();
+      final jsonResponse = JSON.decode(responseBody);
       try {
         return jsonResponse['units'];
       } on Exception catch (e) {
@@ -60,11 +61,13 @@ class Api {
     final uri = Uri.https(url, '/$category/convert',
         {'amount': amount, 'from': fromUnit, 'to': toUnit});
     try {
-      final response = await httpClient.get(uri);
+      final request = await httpClient.getUrl(uri);
+      final response = await request.close();
       if (response.statusCode != 200) {
         return null;
       }
-      final jsonResponse = JSON.decode(response.body);
+      final responseBody = await response.transform(UTF8.decoder).join();
+      final jsonResponse = JSON.decode(responseBody);
       try {
         return jsonResponse['conversion'].toDouble();
       } on Exception catch (e) {


### PR DESCRIPTION
Replaces `createHttpClient` and `package:http` with `dart:io`s HttpClient.  This also better aligns this course with the documentation https://flutter.io/networking/

Note: this is not ready yet, as it may require https://github.com/flutter/flutter/pull/15416 and a new release. (unless the unit_converter test was already broken at master)

Fixes #72