### PR TITLE
move widget state logic outside of build()

### DIFF
--- a/unit_converter/unit_converter/lib/backdrop.dart
+++ b/unit_converter/unit_converter/lib/backdrop.dart
@@ -163,6 +163,10 @@ class _BackdropState extends State<Backdrop>
             velocity:
                 _backdropPanelVisible ? -_kFlingVelocity : _kFlingVelocity);
       });
+    } else if (!_backdropPanelVisible) {
+      setState(() {
+        _controller.fling(velocity: _kFlingVelocity);
+      });
     }
   }
 

--- a/unit_converter/unit_converter/lib/unit_converter.dart
+++ b/unit_converter/unit_converter/lib/unit_converter.dart
@@ -29,12 +29,61 @@ class UnitConverter extends StatefulWidget {
 
 class _UnitConverterState extends State<UnitConverter> {
   final _inputKey = GlobalKey(debugLabel: 'inputText');
+  final units = <DropdownMenuItem>[];
   Unit _fromValue;
   Unit _toValue;
   double _inputValue;
   String _convertedValue = '';
   bool _showErrorUI = false;
   bool _showValidationError = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _createDropdownMenuItems();
+    _setDefaults();
+  }
+
+  @override
+  void didUpdateWidget(UnitConverter old) {
+    super.didUpdateWidget(old);
+    // We update our [DropdownMenuItem] units when we switch [Categories].
+    if (old.category != widget.category) {
+      _createDropdownMenuItems();
+      _setDefaults();
+    }
+  }
+
+  /// Creates fresh list of [DropdownMenuItem] widgets, given a list of [Unit]s.
+  void _createDropdownMenuItems() {
+    units.clear();
+    for (var unit in widget.category.units) {
+      units.add(DropdownMenuItem(
+        value: unit.name,
+        child: Container(
+          child: Text(
+            unit.name,
+            softWrap: true,
+          ),
+        ),
+      ));
+    }
+  }
+
+  /// Sets the default values for the 'from' and 'to' [Dropdown]s, and the new
+  /// output value if a user had previously entered an input in a different
+  /// [Category].
+  void _setDefaults() {
+    setState(() {
+      _fromValue = widget.category.units[0];
+      _toValue = widget.category.units[1];
+    });
+    if (_inputValue != null) {
+      setState(() {
+        _updateConversion();
+      });
+    }
+  }
 
   Future<Null> _updateConversion() async {
     // Our API has a handy convert function, so we can use that for
@@ -190,45 +239,6 @@ class _UnitConverterState extends State<UnitConverter> {
           ),
         ),
       );
-    }
-    final units = <DropdownMenuItem>[];
-    for (var unit in widget.category.units) {
-      units.add(DropdownMenuItem(
-        value: unit.name,
-        child: Container(
-          child: Text(
-            unit.name,
-            softWrap: true,
-          ),
-        ),
-      ));
-    }
-
-    // Update the `from` [DropdownMenuItem] when we switch [Categories]
-    if (_fromValue == null ||
-        !(units.any((unit) {
-          return unit.value == _fromValue.name;
-        }))) {
-      setState(() {
-        _fromValue = widget.category.units[0];
-      });
-    }
-
-    // Update the `to` [DropdownMenuItem] when we switch [Categories]
-    if (_toValue == null ||
-        !(units.any((unit) {
-          return unit.value == _toValue.name;
-        }))) {
-      setState(() {
-        _toValue = widget.category.units[1];
-      });
-
-      // Likewise, update the Output when we switch [Categories]
-      if (_inputValue != null) {
-        setState(() {
-          _updateConversion();
-        });
-      }
     }
 
     final input = Padding(

--- a/unit_converter/unit_converter/lib/unit_converter.dart
+++ b/unit_converter/unit_converter/lib/unit_converter.dart
@@ -29,11 +29,11 @@ class UnitConverter extends StatefulWidget {
 
 class _UnitConverterState extends State<UnitConverter> {
   final _inputKey = GlobalKey(debugLabel: 'inputText');
-  final units = <DropdownMenuItem>[];
   Unit _fromValue;
   Unit _toValue;
   double _inputValue;
   String _convertedValue = '';
+  List<DropdownMenuItem> _unitMenuItems;
   bool _showErrorUI = false;
   bool _showValidationError = false;
 
@@ -56,9 +56,9 @@ class _UnitConverterState extends State<UnitConverter> {
 
   /// Creates fresh list of [DropdownMenuItem] widgets, given a list of [Unit]s.
   void _createDropdownMenuItems() {
-    units.clear();
+    var newItems = <DropdownMenuItem>[];
     for (var unit in widget.category.units) {
-      units.add(DropdownMenuItem(
+      newItems.add(DropdownMenuItem(
         value: unit.name,
         child: Container(
           child: Text(
@@ -68,6 +68,9 @@ class _UnitConverterState extends State<UnitConverter> {
         ),
       ));
     }
+    setState(() {
+      _unitMenuItems = newItems;
+    });
   }
 
   /// Sets the default values for the 'from' and 'to' [Dropdown]s, and the new
@@ -174,8 +177,7 @@ class _UnitConverterState extends State<UnitConverter> {
     }
   }
 
-  Widget _createDropdown(String name, List<DropdownMenuItem> units,
-      ValueChanged<dynamic> onChanged) {
+  Widget _createDropdown(String currentValue, ValueChanged<dynamic> onChanged) {
     return Container(
       margin: EdgeInsets.only(top: 16.0),
       decoration: BoxDecoration(
@@ -196,8 +198,8 @@ class _UnitConverterState extends State<UnitConverter> {
           child: ButtonTheme(
             alignedDropdown: true,
             child: DropdownButton(
-              value: name,
-              items: units,
+              value: currentValue,
+              items: _unitMenuItems,
               onChanged: onChanged,
               style: Theme.of(context).textTheme.title,
             ),
@@ -265,7 +267,7 @@ class _UnitConverterState extends State<UnitConverter> {
             keyboardType: TextInputType.number,
             onChanged: _updateInputValue,
           ),
-          _createDropdown(_fromValue.name, units, _updateFromConversion),
+          _createDropdown(_fromValue.name, _updateFromConversion),
         ],
       ),
     );
@@ -296,7 +298,7 @@ class _UnitConverterState extends State<UnitConverter> {
               ),
             ),
           ),
-          _createDropdown(_toValue.name, units, _updateToConversion),
+          _createDropdown(_toValue.name, _updateToConversion),
         ],
       ),
     );


### PR DESCRIPTION
I realized that a lot of the state logic in the unit converter was being done in build(). In actuality, it should be done in initState() and in didUpdateWidget().

I've done a refactor here.

I also noticed a bug with the Backdrop where if you tap on the same Category consecutively, the front panel will not re-open, so I added an else if to that.