### PR TITLE
Update imls and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
-This repo contains the projects for the Udacity course.
-
 # Getting Started
 This repo contains everything you need for the Udacity course. The Unit Converter app has been broken down into sub-projects, which match a 2-lesson Udacity course. To get started, [set up your development environment](https://flutter.io/setup) and clone this repo, using `git clone git@github.com:flutter/udacity-course.git` or `git clone https://github.com/flutter/udacity-course.git`.
 
 ## Building the Complete Unit Converter App
 ### Android Studio/IntelliJ
-1. Open the IDE and select `Open an existing Android Studio project`.
-2. Choose the `unit_converter` project folder, located in this repo at [`/unit_converter/unit_converter`](https://github.com/flutter/udacity-course/tree/master/unit_converter/unit_converter).
-3. Make sure your Flutter SDK is set and dependencies have been updated.
-4. Make sure your device/emulator is running.
-5. Press the green Play button to run the app.
+1. Open the IDE and select `Import project (Gradle, Eclipse ADT, etc.)`. After you import the first time, you can use `Open an existing Android Studio project` in the future.
+2. Choose the `unit_converter` project folder, located in this repo at [`/unit_converter/unit_converter`](https://github.com/flutter/udacity-course/tree/master/unit_converter/unit_converter). Select `Next` for all setup instructions, making sure that the Source Files screen shows Flutter as an option.
+3. You can view your Flutter app files in the Projects tab in the Project Tool Window (View -> Tool Windows). Make sure your Flutter SDK is set and dependencies have been updated.
+4. Make sure your device/emulator is running. You can view the AVD Manager at Tools -> AVD Manager, or by typing Ctrl/Cmd + Shift + a and typing in 'AVD Manager'.
+5. Press the green Play button to run the app, `main.dart` in the dropdown to the left of the green Play button.
 
 ### Command Line
 1. Run `cd ~/<repo location>/unit_converter/unit_converter`.
@@ -20,18 +18,20 @@ This repo contains everything you need for the Udacity course. The Unit Converte
 Each coding exercise for the Udacity course is located in the [`course` directory](https://github.com/flutter/udacity-course/tree/master/course). Each exercise is split into a standalone Task project and Solution project. The Solution is one of many possible solutions. You can compare your implementation with the solution using the `diff` command.
 
 ### Android Studio/IntelliJ
-1. Open the IDE and select `Open an existing Android Studio project`.
+1. Open the IDE and select `Import project (Gradle, Eclipse ADT, etc.)`. After you import the first time, you can use `Open an existing Android Studio project` in the future.
 2. Find the coding exercise you want to do and choose the `task_` project folder. For example, for the second coding exercise, `02_category_widget`, choose the `task_02_category_widget` project located in this repo at [`/course/2_category_widget/task_02_category_widget`](https://github.com/flutter/udacity-course/tree/master/course/02_category_widget/task_02_category_widget).
-3. Make sure your Flutter SDK is set and dependencies have been updated.
-4. Make sure your device/emulator is running.
-5. Press the green Play button to run the app.
+3. You can view your Flutter app files in the Projects tab in the Project Tool Window (View -> Tool Windows). Make sure your Flutter SDK is set and dependencies have been updated.
+4. Make sure your device/emulator is running. You can view the AVD Manager at Tools -> AVD Manager, or by typing Ctrl/Cmd + Shift + a and typing in 'AVD Manager'.
+5. Press the green Play button to run the app, `main.dart` in the dropdown to the left of the green Play button.
 6. Follow the README and complete the TODOs in the coding exercise.
 
 # Style Guide
 Use strong mode.
 
 # Contribution Guidelines
-Setting up:
+Please feel free to file issues at https://github.com/flutter/udacity-course/issues. Flutter issues can be filed at https://github.com/flutter/flutter/issues.
+
+You can also contribute changes. Setting up:
 1. Fork `https://github.com/flutter/udacity-course` into your own GitHub account
 2. `git clone git@github.com:<your_name_here>/udacity-course.git`
 3. `cd udacity-course`

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This repo contains everything you need for the Udacity course. The Unit Converte
 1. Open the IDE and select `Import project (Gradle, Eclipse ADT, etc.)`. After you import the first time, you can use `Open an existing Android Studio project` in the future.
 2. Choose the `unit_converter` project folder, located in this repo at [`/unit_converter/unit_converter`](https://github.com/flutter/udacity-course/tree/master/unit_converter/unit_converter). Select `Next` for all setup instructions, making sure that the Source Files screen shows Flutter as an option.
 3. You can view your Flutter app files in the Projects tab in the Project Tool Window (View -> Tool Windows). Make sure your Flutter SDK is set and dependencies have been updated.
-4. Make sure your device/emulator is running. You can view the AVD Manager at Tools -> AVD Manager, or by typing Ctrl/Cmd + Shift + a and typing in 'AVD Manager'.
-5. Press the green Play button to run the app, `main.dart` in the dropdown to the left of the green Play button.
+4. Make sure your device/emulator is running. You can view the AVD Manager at Tools -> AVD Manager, or by typing `Ctrl/Cmd` + `Shift` + `a` and typing in 'AVD Manager'.
+5. Press the green Play button to run the app. Note that `main.dart` should be chosen in the dropdown to the left of the green Play button.
 
 ### Command Line
 1. Run `cd ~/<repo location>/unit_converter/unit_converter`.
@@ -21,8 +21,8 @@ Each coding exercise for the Udacity course is located in the [`course` director
 1. Open the IDE and select `Import project (Gradle, Eclipse ADT, etc.)`. After you import the first time, you can use `Open an existing Android Studio project` in the future.
 2. Find the coding exercise you want to do and choose the `task_` project folder. For example, for the second coding exercise, `02_category_widget`, choose the `task_02_category_widget` project located in this repo at [`/course/2_category_widget/task_02_category_widget`](https://github.com/flutter/udacity-course/tree/master/course/02_category_widget/task_02_category_widget).
 3. You can view your Flutter app files in the Projects tab in the Project Tool Window (View -> Tool Windows). Make sure your Flutter SDK is set and dependencies have been updated.
-4. Make sure your device/emulator is running. You can view the AVD Manager at Tools -> AVD Manager, or by typing Ctrl/Cmd + Shift + a and typing in 'AVD Manager'.
-5. Press the green Play button to run the app, `main.dart` in the dropdown to the left of the green Play button.
+4. Make sure your device/emulator is running. You can view the AVD Manager at Tools -> AVD Manager, or by typing `Ctrl/Cmd` + `Shift` + `a` and typing in 'AVD Manager'.
+5. Press the green Play button to run the app. Note that `main.dart` should be chosen in the dropdown to the left of the green Play button.
 6. Follow the README and complete the TODOs in the coding exercise.
 
 # Style Guide

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo contains everything you need for the Udacity course. The Unit Converte
 2. Choose the `unit_converter` project folder, located in this repo at [`/unit_converter/unit_converter`](https://github.com/flutter/udacity-course/tree/master/unit_converter/unit_converter). Select `Next` for all setup instructions, making sure that the Source Files screen shows Flutter as an option.
 3. You can view your Flutter app files in the Projects tab in the Project Tool Window (View -> Tool Windows). Make sure your Flutter SDK is set and dependencies have been updated.
 4. Make sure your device/emulator is running. You can view the AVD Manager at Tools -> AVD Manager, or by typing `Ctrl/Cmd` + `Shift` + `a` and typing in 'AVD Manager'.
-5. Press the green Play button to run the app. Note that `main.dart` should be chosen in the dropdown to the left of the green Play button.
+5. Press the green Play button to run the app. Note that `main.dart` should be chosen in the dropdown on the left of the green Play button.
 
 ### Command Line
 1. Run `cd ~/<repo location>/unit_converter/unit_converter`.
@@ -22,7 +22,7 @@ Each coding exercise for the Udacity course is located in the [`course` director
 2. Find the coding exercise you want to do and choose the `task_` project folder. For example, for the second coding exercise, `02_category_widget`, choose the `task_02_category_widget` project located in this repo at [`/course/2_category_widget/task_02_category_widget`](https://github.com/flutter/udacity-course/tree/master/course/02_category_widget/task_02_category_widget).
 3. You can view your Flutter app files in the Projects tab in the Project Tool Window (View -> Tool Windows). Make sure your Flutter SDK is set and dependencies have been updated.
 4. Make sure your device/emulator is running. You can view the AVD Manager at Tools -> AVD Manager, or by typing `Ctrl/Cmd` + `Shift` + `a` and typing in 'AVD Manager'.
-5. Press the green Play button to run the app. Note that `main.dart` should be chosen in the dropdown to the left of the green Play button.
+5. Press the green Play button to run the app. Note that `main.dart` should be chosen in the dropdown on the left of the green Play button.
 6. Follow the README and complete the TODOs in the coding exercise.
 
 # Style Guide

--- a/course/01_hello_rectangle/solution_01_hello_rectangle/solution_01_hello_rectangle.iml
+++ b/course/01_hello_rectangle/solution_01_hello_rectangle/solution_01_hello_rectangle.iml
@@ -1,18 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
+<module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/packages" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/02_category_widget/solution_02_category_widget/solution_02_category_widget.iml
+++ b/course/02_category_widget/solution_02_category_widget/solution_02_category_widget.iml
@@ -1,18 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
+<module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/packages" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/02_category_widget/task_02_category_widget/task_02_category_widget.iml
+++ b/course/02_category_widget/task_02_category_widget/task_02_category_widget.iml
@@ -1,18 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
+<module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/packages" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/03_category_route/solution_03_category_route/solution_03_category_route.iml
+++ b/course/03_category_route/solution_03_category_route/solution_03_category_route.iml
@@ -1,18 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
+<module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/packages" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/03_category_route/task_03_category_route/task_03_category_route.iml
+++ b/course/03_category_route/task_03_category_route/task_03_category_route.iml
@@ -1,18 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
+<module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/packages" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/04_navigation/solution_04_navigation/solution_04_navigation.iml
+++ b/course/04_navigation/solution_04_navigation/solution_04_navigation.iml
@@ -1,18 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
+<module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/packages" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/04_navigation/task_04_navigation/task_04_navigation.iml
+++ b/course/04_navigation/task_04_navigation/task_04_navigation.iml
@@ -1,18 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
+<module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/packages" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/05_stateful_widgets/solution_05_stateful_widgets/solution_05_stateful_widgets.iml
+++ b/course/05_stateful_widgets/solution_05_stateful_widgets/solution_05_stateful_widgets.iml
@@ -1,17 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
+<module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/05_stateful_widgets/task_05_stateful_widgets/task_05_stateful_widgets.iml
+++ b/course/05_stateful_widgets/task_05_stateful_widgets/task_05_stateful_widgets.iml
@@ -1,17 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
+<module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/06_input/solution_06_input/solution_06_input.iml
+++ b/course/06_input/solution_06_input/solution_06_input.iml
@@ -3,16 +3,12 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/06_input/task_06_input/task_06_input.iml
+++ b/course/06_input/task_06_input/task_06_input.iml
@@ -3,16 +3,12 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/07_backdrop/solution_07_backdrop/solution_07_backdrop.iml
+++ b/course/07_backdrop/solution_07_backdrop/solution_07_backdrop.iml
@@ -3,16 +3,12 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/07_backdrop/task_07_backdrop/task_07_backdrop.iml
+++ b/course/07_backdrop/task_07_backdrop/task_07_backdrop.iml
@@ -3,16 +3,12 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/08_responsive/solution_08_responsive/solution_08_responsive.iml
+++ b/course/08_responsive/solution_08_responsive/solution_08_responsive.iml
@@ -3,16 +3,12 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/08_responsive/task_08_responsive/task_08_responsive.iml
+++ b/course/08_responsive/task_08_responsive/task_08_responsive.iml
@@ -3,16 +3,12 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/09_units/solution_09_units/solution_09_units.iml
+++ b/course/09_units/solution_09_units/solution_09_units.iml
@@ -3,16 +3,12 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/09_units/task_09_units/task_09_units.iml
+++ b/course/09_units/task_09_units/task_09_units.iml
@@ -3,16 +3,12 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/10_icons_fonts/solution_10_icons_fonts/solution_10_icons_fonts.iml
+++ b/course/10_icons_fonts/solution_10_icons_fonts/solution_10_icons_fonts.iml
@@ -3,16 +3,12 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/10_icons_fonts/task_10_icons_fonts/task_10_icons_fonts.iml
+++ b/course/10_icons_fonts/task_10_icons_fonts/task_10_icons_fonts.iml
@@ -3,16 +3,12 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/11_api/solution_11_api/solution_11_api.iml
+++ b/course/11_api/solution_11_api/solution_11_api.iml
@@ -3,16 +3,12 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/11_api/task_11_api/task_11_api.iml
+++ b/course/11_api/task_11_api/task_11_api.iml
@@ -3,16 +3,12 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/12_error/solution_12_error/solution_12_error.iml
+++ b/course/12_error/solution_12_error/solution_12_error.iml
@@ -3,16 +3,12 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/course/12_error/task_12_error/task_12_error.iml
+++ b/course/12_error/task_12_error/task_12_error.iml
@@ -3,16 +3,12 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
-      <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/todo/todo.iml
+++ b/todo/todo.iml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
+<module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/unit_converter/unit_converter/unit_converter.iml
+++ b/unit_converter/unit_converter/unit_converter.iml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
+<module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/test/packages" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
     <orderEntry type="library" name="Dart Packages" level="project" />


### PR DESCRIPTION
- Update .iml files to point to JAVA_MODULE instead of WEB_MODULE
- Import project, instead of open project, because otherwise the AVD Manager doesn't show up in Tools (see https://github.com/flutter/flutter-intellij/issues/2159)