### PR TITLE
Remove semicolon at end of import string in solution 05

### DIFF
--- a/course/05_stateful_widgets/solution_05_stateful_widgets/lib/main.dart
+++ b/course/05_stateful_widgets/solution_05_stateful_widgets/lib/main.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 // You can use a relative import, i.e. `import 'category_route.dart;'` or
 // a package import, as shown below.
 // More details at http://dart-lang.github.io/linter/lints/avoid_relative_lib_imports.html
-import 'package:solution_05_stateful_widgets/category_route.dart;';
+import 'package:solution_05_stateful_widgets/category_route.dart';
 
 /// The function that is called when main.dart is run.
 void main() {


### PR DESCRIPTION
I ran into an issue building the solution to task 05. Turns out a semicolon slipped into the import of `category_route.dart`. This (very minor) PR removes the semicolon, which should fix the issue. As far as I could find this was also the only instance where this happened.