### PR TITLE
Check `_currentCategory == null` more concisely

### DIFF
--- a/course/07_backdrop/solution_07_backdrop/lib/category_route.dart
+++ b/course/07_backdrop/solution_07_backdrop/lib/category_route.dart
@@ -136,11 +136,8 @@ class _CategoryRouteState extends State<CategoryRoute> {
     );
 
     return Backdrop(
-      currentCategory:
-          _currentCategory == null ? _defaultCategory : _currentCategory,
-      frontPanel: _currentCategory == null
-          ? UnitConverter(category: _defaultCategory)
-          : UnitConverter(category: _currentCategory),
+      currentCategory: _currentCategory ?? _defaultCategory,
+      frontPanel: UnitConverter(category: _currentCategory ?? _defaultCategory),
       backPanel: listView,
       frontTitle: Text('Unit Converter'),
       backTitle: Text('Select a Category'),


### PR DESCRIPTION
I am referring to lines 139 and 140. Wouldn't it be better to replace `_currentCategory == null ? _defaultCategory : _currentCategory` with just `_currentCategory ?? _defaultCategory`.
It has the exact same meaning, but the second option is a lot more concise. Furthermore consider that the null-aware operator `??` was built precisely for this type of evaluation.