### PR TITLE
Hotfix/soft keyboard issue

### DIFF
--- a/course/07_backdrop/solution_07_backdrop/lib/backdrop.dart
+++ b/course/07_backdrop/solution_07_backdrop/lib/backdrop.dart
@@ -183,6 +183,7 @@ class _BackdropState extends State<Backdrop>
   }
 
   void _toggleBackdropPanelVisibility() {
+    FocusScope.of(context).requestFocus(FocusNode());
     _controller.fling(
         velocity: _backdropPanelVisible ? -_kFlingVelocity : _kFlingVelocity);
   }

--- a/course/07_backdrop/task_07_backdrop/lib/backdrop.dart
+++ b/course/07_backdrop/task_07_backdrop/lib/backdrop.dart
@@ -183,6 +183,7 @@ class _BackdropState extends State<Backdrop>
   }
 
   void _toggleBackdropPanelVisibility() {
+    FocusScope.of(context).requestFocus(FocusNode());
     _controller.fling(
         velocity: _backdropPanelVisible ? -_kFlingVelocity : _kFlingVelocity);
   }

--- a/course/08_responsive/solution_08_responsive/lib/backdrop.dart
+++ b/course/08_responsive/solution_08_responsive/lib/backdrop.dart
@@ -183,6 +183,7 @@ class _BackdropState extends State<Backdrop>
   }
 
   void _toggleBackdropPanelVisibility() {
+    FocusScope.of(context).requestFocus(FocusNode());
     _controller.fling(
         velocity: _backdropPanelVisible ? -_kFlingVelocity : _kFlingVelocity);
   }

--- a/course/08_responsive/task_08_responsive/lib/backdrop.dart
+++ b/course/08_responsive/task_08_responsive/lib/backdrop.dart
@@ -183,6 +183,7 @@ class _BackdropState extends State<Backdrop>
   }
 
   void _toggleBackdropPanelVisibility() {
+    FocusScope.of(context).requestFocus(FocusNode());
     _controller.fling(
         velocity: _backdropPanelVisible ? -_kFlingVelocity : _kFlingVelocity);
   }

--- a/course/09_units/solution_09_units/lib/backdrop.dart
+++ b/course/09_units/solution_09_units/lib/backdrop.dart
@@ -183,6 +183,7 @@ class _BackdropState extends State<Backdrop>
   }
 
   void _toggleBackdropPanelVisibility() {
+    FocusScope.of(context).requestFocus(FocusNode());
     _controller.fling(
         velocity: _backdropPanelVisible ? -_kFlingVelocity : _kFlingVelocity);
   }

--- a/course/09_units/task_09_units/lib/backdrop.dart
+++ b/course/09_units/task_09_units/lib/backdrop.dart
@@ -183,6 +183,7 @@ class _BackdropState extends State<Backdrop>
   }
 
   void _toggleBackdropPanelVisibility() {
+    FocusScope.of(context).requestFocus(FocusNode());
     _controller.fling(
         velocity: _backdropPanelVisible ? -_kFlingVelocity : _kFlingVelocity);
   }

--- a/course/10_icons_fonts/solution_10_icons_fonts/lib/backdrop.dart
+++ b/course/10_icons_fonts/solution_10_icons_fonts/lib/backdrop.dart
@@ -183,6 +183,7 @@ class _BackdropState extends State<Backdrop>
   }
 
   void _toggleBackdropPanelVisibility() {
+    FocusScope.of(context).requestFocus(FocusNode());
     _controller.fling(
         velocity: _backdropPanelVisible ? -_kFlingVelocity : _kFlingVelocity);
   }

--- a/course/10_icons_fonts/task_10_icons_fonts/lib/backdrop.dart
+++ b/course/10_icons_fonts/task_10_icons_fonts/lib/backdrop.dart
@@ -183,6 +183,7 @@ class _BackdropState extends State<Backdrop>
   }
 
   void _toggleBackdropPanelVisibility() {
+    FocusScope.of(context).requestFocus(FocusNode());
     _controller.fling(
         velocity: _backdropPanelVisible ? -_kFlingVelocity : _kFlingVelocity);
   }

--- a/course/11_api/solution_11_api/lib/backdrop.dart
+++ b/course/11_api/solution_11_api/lib/backdrop.dart
@@ -183,7 +183,6 @@ class _BackdropState extends State<Backdrop>
   }
 
   void _toggleBackdropPanelVisibility() {
-    print("start animation");
     FocusScope.of(context).requestFocus(FocusNode());
     _controller.fling(
         velocity: _backdropPanelVisible ? -_kFlingVelocity : _kFlingVelocity);
@@ -240,10 +239,7 @@ class _BackdropState extends State<Backdrop>
           PositionedTransition(
             rect: panelAnimation,
             child: _BackdropPanel(
-              onTap: () {
-                print("On tap is called");
-                _toggleBackdropPanelVisibility();
-              },
+              onTap: _toggleBackdropPanelVisibility,
               onVerticalDragUpdate: _handleDragUpdate,
               onVerticalDragEnd: _handleDragEnd,
               title: Text(widget.currentCategory.name),
@@ -262,10 +258,7 @@ class _BackdropState extends State<Backdrop>
         backgroundColor: widget.currentCategory.color,
         elevation: 0.0,
         leading: IconButton(
-          onPressed: () {
-            print("On pressed is called");
-            _toggleBackdropPanelVisibility();
-          },
+          onPressed: _toggleBackdropPanelVisibility,
           icon: AnimatedIcon(
             icon: AnimatedIcons.close_menu,
             progress: _controller.view,

--- a/course/11_api/solution_11_api/lib/backdrop.dart
+++ b/course/11_api/solution_11_api/lib/backdrop.dart
@@ -183,6 +183,8 @@ class _BackdropState extends State<Backdrop>
   }
 
   void _toggleBackdropPanelVisibility() {
+    print("start animation");
+    FocusScope.of(context).requestFocus(FocusNode());
     _controller.fling(
         velocity: _backdropPanelVisible ? -_kFlingVelocity : _kFlingVelocity);
   }
@@ -238,7 +240,10 @@ class _BackdropState extends State<Backdrop>
           PositionedTransition(
             rect: panelAnimation,
             child: _BackdropPanel(
-              onTap: _toggleBackdropPanelVisibility,
+              onTap: () {
+                print("On tap is called");
+                _toggleBackdropPanelVisibility();
+              },
               onVerticalDragUpdate: _handleDragUpdate,
               onVerticalDragEnd: _handleDragEnd,
               title: Text(widget.currentCategory.name),
@@ -257,7 +262,10 @@ class _BackdropState extends State<Backdrop>
         backgroundColor: widget.currentCategory.color,
         elevation: 0.0,
         leading: IconButton(
-          onPressed: _toggleBackdropPanelVisibility,
+          onPressed: () {
+            print("On pressed is called");
+            _toggleBackdropPanelVisibility();
+          },
           icon: AnimatedIcon(
             icon: AnimatedIcons.close_menu,
             progress: _controller.view,

--- a/course/11_api/task_11_api/lib/backdrop.dart
+++ b/course/11_api/task_11_api/lib/backdrop.dart
@@ -183,6 +183,7 @@ class _BackdropState extends State<Backdrop>
   }
 
   void _toggleBackdropPanelVisibility() {
+    FocusScope.of(context).requestFocus(FocusNode());
     _controller.fling(
         velocity: _backdropPanelVisible ? -_kFlingVelocity : _kFlingVelocity);
   }

--- a/course/12_error/solution_12_error/lib/backdrop.dart
+++ b/course/12_error/solution_12_error/lib/backdrop.dart
@@ -183,6 +183,7 @@ class _BackdropState extends State<Backdrop>
   }
 
   void _toggleBackdropPanelVisibility() {
+    FocusScope.of(context).requestFocus(FocusNode());
     _controller.fling(
         velocity: _backdropPanelVisible ? -_kFlingVelocity : _kFlingVelocity);
   }

--- a/course/12_error/task_12_error/lib/backdrop.dart
+++ b/course/12_error/task_12_error/lib/backdrop.dart
@@ -183,6 +183,7 @@ class _BackdropState extends State<Backdrop>
   }
 
   void _toggleBackdropPanelVisibility() {
+    FocusScope.of(context).requestFocus(FocusNode());
     _controller.fling(
         velocity: _backdropPanelVisible ? -_kFlingVelocity : _kFlingVelocity);
   }

--- a/unit_converter/unit_converter/lib/backdrop.dart
+++ b/unit_converter/unit_converter/lib/backdrop.dart
@@ -183,6 +183,7 @@ class _BackdropState extends State<Backdrop>
   }
 
   void _toggleBackdropPanelVisibility() {
+    FocusScope.of(context).requestFocus(FocusNode());
     _controller.fling(
         velocity: _backdropPanelVisible ? -_kFlingVelocity : _kFlingVelocity);
   }

--- a/unit_converter/unit_converter/lib/category_route.dart
+++ b/unit_converter/unit_converter/lib/category_route.dart
@@ -167,39 +167,6 @@ class _CategoryRouteState extends State<CategoryRoute> {
     });
   }
 
-  /// Makes the correct number of rows for the list view, based on whether the
-  /// device is portrait or landscape.
-  ///
-  /// For portrait, we use a [ListView]. For landscape, we use a [GridView].
-  Widget _buildCategoryWidgets(Orientation deviceOrientation) {
-    if (deviceOrientation == Orientation.portrait) {
-      return ListView.builder(
-        itemBuilder: (BuildContext context, int index) {
-          var _category = _categories[index];
-          return CategoryTile(
-            category: _category,
-            onTap:
-                _category.name == apiCategory['name'] && _category.units.isEmpty
-                    ? null
-                    : _onCategoryTap,
-          );
-        },
-        itemCount: _categories.length,
-      );
-    } else {
-      return GridView.count(
-        crossAxisCount: 2,
-        childAspectRatio: 3.0,
-        children: _categories.map((Category c) {
-          return CategoryTile(
-            category: c,
-            onTap: _onCategoryTap,
-          );
-        }).toList(),
-      );
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     if (_categories.isEmpty) {

--- a/unit_converter/unit_converter/lib/category_route.dart
+++ b/unit_converter/unit_converter/lib/category_route.dart
@@ -221,7 +221,34 @@ class _CategoryRouteState extends State<CategoryRoute> {
         right: 8.0,
         bottom: 48.0,
       ),
-      child: _buildCategoryWidgets(MediaQuery.of(context).orientation),
+      child: OrientationBuilder(builder: (context, orientation) {
+        if (orientation == Orientation.portrait) {
+          return ListView.builder(
+            itemBuilder: (BuildContext context, int index) {
+              var _category = _categories[index];
+              return CategoryTile(
+                category: _category,
+                onTap:
+                _category.name == apiCategory['name'] && _category.units.isEmpty
+                    ? null
+                    : _onCategoryTap,
+              );
+            },
+            itemCount: _categories.length,
+          );
+        } else {
+          return GridView.count(
+            crossAxisCount: 2,
+            childAspectRatio: 3.0,
+            children: _categories.map((Category c) {
+              return CategoryTile(
+                category: c,
+                onTap: _onCategoryTap,
+              );
+            }).toList(),
+          );
+        }
+      }),
     );
     return Backdrop(
       currentCategory:


### PR DESCRIPTION
> **Created new branch to resolve issue in cla/google occur by commit from wrong user name.**


Open issue: 
After opening front panel by selecting any category, when user clicks on hamburger icon the front panel and soft keyboard closed and front panel opens again automatically.

Expected behaviour :
When user clicks on hamburger icon soft keyboard should be closed and front panel should not open automatically again.

This issue was created due to MediaQuery used in category_route.dart. I resolved that issue in [unit_converter app](https://github.com/flutter/udacity-course/tree/master/unit_converter/unit_converter).

Did not change in any other project because in video series MediaQuery is used to explain the concept of Responsive design.