### PR TITLE
Update unit_converter.dart

### DIFF
--- a/unit_converter/unit_converter/lib/unit_converter.dart
+++ b/unit_converter/unit_converter/lib/unit_converter.dart
@@ -116,6 +116,7 @@ class _UnitConverterState extends State<UnitConverter> {
         });
       } else {
         setState(() {
+          _showErrorUI = false;
           _convertedValue = _format(conversion);
         });
       }


### PR DESCRIPTION
Added line 119 `_showErrorUI = false;`. Now after receiving an error, and then that error is fixed, the error screen will go away without having to restart the app.