### PR TITLE
_showErrorUI flag update

### DIFF
--- a/course/12_error/solution_12_error/lib/unit_converter.dart
+++ b/course/12_error/solution_12_error/lib/unit_converter.dart
@@ -116,6 +116,7 @@ class _UnitConverterState extends State<UnitConverter> {
         });
       } else {
         setState(() {
+          _showErrorUI = false;
           _convertedValue = _format(conversion);
         });
       }

--- a/unit_converter/unit_converter/lib/unit_converter.dart
+++ b/unit_converter/unit_converter/lib/unit_converter.dart
@@ -116,6 +116,7 @@ class _UnitConverterState extends State<UnitConverter> {
         });
       } else {
         setState(() {
+		  _showErrorUI = false;
           _convertedValue = _format(conversion);
         });
       }


### PR DESCRIPTION
A `_showErrorUI` flag update added to `unit_converter.dart` so that after receiving an error, and then that error is fixed, the error screen will go away without having to restart the app.