### PR TITLE
update sdk constraints

### DIFF
--- a/course/01_hello_rectangle/solution_01_hello_rectangle/pubspec.yaml
+++ b/course/01_hello_rectangle/solution_01_hello_rectangle/pubspec.yaml
@@ -1,6 +1,9 @@
 name: solution_01_hello_rectangle
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/02_category_widget/solution_02_category_widget/pubspec.yaml
+++ b/course/02_category_widget/solution_02_category_widget/pubspec.yaml
@@ -1,6 +1,9 @@
 name: solution_02_category_widget
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/02_category_widget/task_02_category_widget/pubspec.yaml
+++ b/course/02_category_widget/task_02_category_widget/pubspec.yaml
@@ -1,6 +1,9 @@
 name: task_02_category_widget
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/03_category_route/solution_03_category_route/pubspec.yaml
+++ b/course/03_category_route/solution_03_category_route/pubspec.yaml
@@ -1,6 +1,9 @@
 name: solution_03_category_route
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/03_category_route/task_03_category_route/pubspec.yaml
+++ b/course/03_category_route/task_03_category_route/pubspec.yaml
@@ -1,6 +1,9 @@
 name: task_03_category_route
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/04_navigation/solution_04_navigation/pubspec.yaml
+++ b/course/04_navigation/solution_04_navigation/pubspec.yaml
@@ -1,6 +1,9 @@
 name: solution_04_navigation
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/04_navigation/task_04_navigation/pubspec.yaml
+++ b/course/04_navigation/task_04_navigation/pubspec.yaml
@@ -1,6 +1,9 @@
 name: task_04_navigation
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/05_stateful_widgets/solution_05_stateful_widgets/pubspec.yaml
+++ b/course/05_stateful_widgets/solution_05_stateful_widgets/pubspec.yaml
@@ -1,6 +1,9 @@
 name: solution_05_stateful_widgets
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/05_stateful_widgets/task_05_stateful_widgets/pubspec.yaml
+++ b/course/05_stateful_widgets/task_05_stateful_widgets/pubspec.yaml
@@ -1,6 +1,9 @@
 name: task_05_stateful_widgets
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/06_input/solution_06_input/pubspec.yaml
+++ b/course/06_input/solution_06_input/pubspec.yaml
@@ -1,6 +1,9 @@
 name: solution_06_input
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/06_input/task_06_input/pubspec.yaml
+++ b/course/06_input/task_06_input/pubspec.yaml
@@ -1,6 +1,9 @@
 name: task_06_input
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/07_backdrop/solution_07_backdrop/pubspec.yaml
+++ b/course/07_backdrop/solution_07_backdrop/pubspec.yaml
@@ -1,6 +1,9 @@
 name: solution_07_backdrop
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/07_backdrop/task_07_backdrop/pubspec.yaml
+++ b/course/07_backdrop/task_07_backdrop/pubspec.yaml
@@ -1,6 +1,9 @@
 name: task_07_backdrop
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/08_responsive/solution_08_responsive/pubspec.yaml
+++ b/course/08_responsive/solution_08_responsive/pubspec.yaml
@@ -1,6 +1,9 @@
 name: solution_08_responsive
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/08_responsive/task_08_responsive/pubspec.yaml
+++ b/course/08_responsive/task_08_responsive/pubspec.yaml
@@ -1,6 +1,9 @@
 name: task_08_responsive
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/09_units/solution_09_units/pubspec.yaml
+++ b/course/09_units/solution_09_units/pubspec.yaml
@@ -1,6 +1,9 @@
 name: solution_09_units
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/09_units/task_09_units/pubspec.yaml
+++ b/course/09_units/task_09_units/pubspec.yaml
@@ -1,6 +1,9 @@
 name: task_09_units
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/10_icons_fonts/solution_10_icons_fonts/pubspec.yaml
+++ b/course/10_icons_fonts/solution_10_icons_fonts/pubspec.yaml
@@ -1,6 +1,9 @@
 name: solution_10_icons_fonts
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/10_icons_fonts/task_10_icons_fonts/pubspec.yaml
+++ b/course/10_icons_fonts/task_10_icons_fonts/pubspec.yaml
@@ -1,6 +1,9 @@
 name: task_10_icons_fonts
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/11_api/solution_11_api/pubspec.yaml
+++ b/course/11_api/solution_11_api/pubspec.yaml
@@ -1,6 +1,9 @@
 name: solution_11_api
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/11_api/task_11_api/pubspec.yaml
+++ b/course/11_api/task_11_api/pubspec.yaml
@@ -1,6 +1,9 @@
 name: task_11_api
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/12_error/solution_12_error/pubspec.yaml
+++ b/course/12_error/solution_12_error/pubspec.yaml
@@ -1,6 +1,9 @@
 name: solution_12_error
 description: Unit Converter App that takes in a value and unit and outputs a conversion in another unit.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/course/12_error/task_12_error/pubspec.yaml
+++ b/course/12_error/task_12_error/pubspec.yaml
@@ -1,6 +1,9 @@
 name: task_12_error
 description: Work in progress for a Unit Converter app.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter


### PR DESCRIPTION
Updating `pubspec.yaml` with sdk constraints.

> As of Dart 2.12, omitting the SDK constraint is an error. When the pubspec has no SDK constraint, pub get fails with a message

As from [docs](https://dart.dev/tools/pub/pubspec#sdk-constraints)