### PR TITLE
update deprecated resizeToAvoidBottomPadding

### DIFF
--- a/course/06_input/solution_06_input/lib/category.dart
+++ b/course/06_input/solution_06_input/lib/category.dart
@@ -65,7 +65,7 @@ class Category extends StatelessWidget {
           ),
           // This prevents the attempt to resize the screen when the keyboard
           // is opened
-          resizeToAvoidBottomPadding: false,
+          resizeToAvoidBottomInset: false,
         );
       },
     ));

--- a/course/06_input/task_06_input/lib/category.dart
+++ b/course/06_input/task_06_input/lib/category.dart
@@ -65,7 +65,7 @@ class Category extends StatelessWidget {
           ),
           // This prevents the attempt to resize the screen when the keyboard
           // is opened
-          resizeToAvoidBottomPadding: false,
+          resizeToAvoidBottomInset: false,
         );
       },
     ));

--- a/course/07_backdrop/solution_07_backdrop/lib/backdrop.dart
+++ b/course/07_backdrop/solution_07_backdrop/lib/backdrop.dart
@@ -273,7 +273,7 @@ class _BackdropState extends State<Backdrop>
       body: LayoutBuilder(
         builder: _buildStack,
       ),
-      resizeToAvoidBottomPadding: false,
+      resizeToAvoidBottomInset: false,
     );
   }
 }

--- a/course/07_backdrop/task_07_backdrop/lib/category_tile.dart
+++ b/course/07_backdrop/task_07_backdrop/lib/category_tile.dart
@@ -49,7 +49,7 @@ class CategoryTile extends StatelessWidget {
           body: UnitConverter(category: category),
           // This prevents the attempt to resize the screen when the keyboard
           // is opened
-          resizeToAvoidBottomPadding: false,
+          resizeToAvoidBottomInset: false,
         );
       },
     ));

--- a/course/08_responsive/solution_08_responsive/lib/backdrop.dart
+++ b/course/08_responsive/solution_08_responsive/lib/backdrop.dart
@@ -273,7 +273,7 @@ class _BackdropState extends State<Backdrop>
       body: LayoutBuilder(
         builder: _buildStack,
       ),
-      resizeToAvoidBottomPadding: false,
+      resizeToAvoidBottomInset: false,
     );
   }
 }

--- a/course/08_responsive/task_08_responsive/lib/backdrop.dart
+++ b/course/08_responsive/task_08_responsive/lib/backdrop.dart
@@ -273,7 +273,7 @@ class _BackdropState extends State<Backdrop>
       body: LayoutBuilder(
         builder: _buildStack,
       ),
-      resizeToAvoidBottomPadding: false,
+      resizeToAvoidBottomInset: false,
     );
   }
 }

--- a/course/code-snippets/lesson_1_12_demo.dart
+++ b/course/code-snippets/lesson_1_12_demo.dart
@@ -54,13 +54,13 @@ class Category extends StatelessWidget {
           ),
           // This prevents the onscreen keyboard from affecting the size of the
           // screen, and the space given to widgets.
-          // See https://docs.flutter.io/flutter/material/Scaffold/resizeToAvoidBottomPadding.html
-          resizeToAvoidBottomPadding: false,
+          // See https://api.flutter.dev/flutter/material/Scaffold/resizeToAvoidBottomInset.html
+          resizeToAvoidBottomInset: false,
         );
       },
     ));
   }
-  
+
   /// Builds a widget that shows [Category] information, using [ListTile]
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));


### PR DESCRIPTION
Changing deprecated `resizeToAvoidBottomPadding` to `resizeToAvoidBottomInset `.

> The resizeToAvoidBottomPadding parameter of Scaffold was deprecated in in v1.1.9. The resizeToAvoidBottomInset parameter should be used instead.

As from docs: https://flutter.dev/docs/release/breaking-changes/1-22-deprecations#scaffoldresizetoavoidbottompadding

Removed in https://github.com/flutter/flutter/pull/72890

Could you please review @maryx @domesticmouse 